### PR TITLE
Tlm renamed communications variable/method names to telemetry

### DIFF
--- a/src/data/data.cpp
+++ b/src/data/data.cpp
@@ -151,16 +151,16 @@ void Data::setMotorData(const Motors& motor_data)
   motors_ = motor_data;
 }
 
-Communications Data::getCommunicationsData()
+Telemetry Data::getTelemetryData()
 {
-  ScopedLock L(&lock_communications_);
-  return communications_;
+  ScopedLock L(&lock_telemetry_);
+  return telemetry_;
 }
 
-void Data::setCommunicationsData(const Communications& communications_data)
+void Data::setTelemetryData(const Telemetry& telemetry_data)
 {
-  ScopedLock L(&lock_communications_);
-  communications_ = communications_data;
+  ScopedLock L(&lock_telemetry_);
+  telemetry_ = telemetry_data;
 }
 
 }}  // namespace data::hyped

--- a/src/data/data.hpp
+++ b/src/data/data.hpp
@@ -126,10 +126,10 @@ struct Motors : public Module {
 };
 
 // -------------------------------------------------------------------------------------------------
-// Communications data
+// Telemetry data
 // -------------------------------------------------------------------------------------------------
 
-struct Communications : public Module {
+struct Telemetry : public Module {
   bool launch_command;
   bool reset_command;
   float run_length;  // m
@@ -269,12 +269,12 @@ class Data {
   /**
    * @brief      Retrieves data on whether stop/kill power commands have been issued.
    */
-  Communications getCommunicationsData();
+  Telemetry getTelemetryData();
 
   /**
    * @brief      Should be called to update communications data.
    */
-  void setCommunicationsData(const Communications& communications_data);
+  void setTelemetryData(const Telemetry& telemetry_data);
 
  private:
   StateMachine state_machine_;
@@ -282,7 +282,7 @@ class Data {
   Sensors sensors_;
   Motors motors_;
   Batteries batteries_;
-  Communications communications_;
+  Telemetry telemetry_;
   SensorCalibration calibration_data_;
   EmergencyBrakes emergency_brakes_;
   int temperature_;  // In degrees C
@@ -295,7 +295,7 @@ class Data {
   Lock lock_motors_;
   Lock lock_temp_;
 
-  Lock lock_communications_;
+  Lock lock_telemetry_;
   Lock lock_batteries_;
   Lock lock_emergency_brakes_;
   Lock lock_calibration_data_;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,7 +34,7 @@ int main(int argc, char* argv[])
   Logger log_nav(sys.verbose_nav, sys.debug_nav);
   Logger log_sensor(sys.verbose_sensor, sys.debug_sensor);
   Logger log_state(sys.verbose_state, sys.debug_state);
-  Logger log_cmn(sys.verbose_tlm, sys.debug_tlm);
+  Logger log_tlm(sys.verbose_tlm, sys.debug_tlm);
 
   log_system.INFO("MAIN", "Starting BBB with %d modules", 5);
   log_system.DBG("MAIN", "DBG0");

--- a/src/state_machine/main.hpp
+++ b/src/state_machine/main.hpp
@@ -49,7 +49,7 @@ class Main: public Thread {
   bool checkSystemsChecked();
   bool checkReset();
   bool checkOnStart();
-  bool checkCommsCriticalFailure();
+  bool checkTelemetryCriticalFailure();
   bool checkCriticalFailure();
   bool checkMaxDistanceReached();
   bool checkOnExit();
@@ -61,7 +61,7 @@ class Main: public Thread {
   uint64_t timeout_;
 
   data::Data&           data_;
-  data::Communications  comms_data_;
+  data::Telemetry       telemetry_data_;
   data::Navigation      nav_data_;
   data::StateMachine    sm_data_;
   data::Motors          motor_data_;


### PR DESCRIPTION
Hey guys, for some reason there was a discrepancy in naming regarding variables and methods for Telemetry stuff in `Data.hpp`/`Data.cpp` and `System.hpp`/`System.cpp` (methods in Data files where named `setCommsData` while variables in System files were name `debug_tlm`). Greg and I wanted to make this consistent so we just decided to rename everything to `Telemetry`. As you can see in the commits below I had to rename some of the stuff in the state machine code, hopefully this doesn't bother you guys. Let me know if anythings wrong or want to change something.