### PR TITLE
fix stationary_run system argument

### DIFF
--- a/src/utils/system.cpp
+++ b/src/utils/system.cpp
@@ -260,6 +260,7 @@ System::System(int argc, char* argv[])
           stationary_run = 1;
           tube_run = 0;
         }
+        break;
       default:
         printUsage();
         exit(1);


### PR DESCRIPTION
add necessary break for stationary_run system argument (navigation run type for stationary tests)