### PR TITLE
Sns battery ssr

### DIFF
--- a/src/sensors/bms_manager.cpp
+++ b/src/sensors/bms_manager.cpp
@@ -67,6 +67,7 @@ BmsManager::BmsManager(Logger& log)
 
 void BmsManager::run()
 {
+  GPIO kill_switch(kSSRKill, utils::io::gpio::kOut);
   while (sys_.running_) {
     // keep updating data_ based on values read from sensors
     for (int i = 0; i < data::Batteries::kNumLPBatteries; i++) {
@@ -91,7 +92,6 @@ void BmsManager::run()
 
     // set high to kSSRKill if LP or HP is kCriticalFailure
     if (batteries_.module_status == data::ModuleStatus::kCriticalFailure) {
-      GPIO kill_switch(kSSRKill, utils::io::gpio::kOut);
       kill_switch.set();
       log_.INFO("BMS-MANAGER", "SSR Kill Switch has been set");
     }

--- a/src/sensors/bms_manager.cpp
+++ b/src/sensors/bms_manager.cpp
@@ -27,8 +27,14 @@
 #include "data/data.hpp"
 #include "utils/timer.hpp"
 #include "sensors/fake_batteries.hpp"
+#include "utils/io/gpio.hpp"
+
+constexpr int kSSRKill = 70;
 
 namespace hyped {
+
+using utils::io::GPIO;
+
 namespace sensors {
 
 BmsManager::BmsManager(Logger& log)

--- a/src/sensors/bms_manager.cpp
+++ b/src/sensors/bms_manager.cpp
@@ -73,7 +73,7 @@ BmsManager::BmsManager(Logger& log)
 
 void BmsManager::run()
 {
-  GPIO kill_switch(kSSRKill, utils::io::gpio::kOut);
+  GPIO kill_switch(kSSRKill, utils::io::gpio::kOut);    // HP SSR only
   while (sys_.running_) {
     // keep updating data_ based on values read from sensors
     for (int i = 0; i < data::Batteries::kNumLPBatteries; i++) {
@@ -97,9 +97,10 @@ void BmsManager::run()
     data_.setBatteriesData(batteries_);
 
     // set high to kSSRKill if LP or HP is kCriticalFailure
+    // batteries module status forces kEmergencyBraking, which actuates embrakes
     if (batteries_.module_status == data::ModuleStatus::kCriticalFailure) {
       kill_switch.set();
-      log_.INFO("BMS-MANAGER", "SSR Kill Switch has been set");
+      log_.INFO("BMS-MANAGER", "SSR Kill Switch has been set: HP shut off...LP still running");
     }
     sleep(100);
   }
@@ -107,9 +108,6 @@ void BmsManager::run()
 
 bool BmsManager::batteriesInRange()
 {
-  // TODO(Greg): Check these values with power team
-  // check all LP and HP battery values are in expected range
-
   // check LP
   for (int i = 0; i < data::Batteries::kNumLPBatteries; i++) {
     auto& battery = batteries_.low_power_batteries[i];      // reference batteries individually

--- a/src/sensors/bms_manager.hpp
+++ b/src/sensors/bms_manager.hpp
@@ -31,16 +31,12 @@
 #include "data/data.hpp"
 #include "sensors/interface.hpp"
 #include "utils/system.hpp"
-#include "utils/io/gpio.hpp"
-
-constexpr int kSSRKill = 70;
 
 namespace hyped {
 
 using utils::concurrent::Thread;
 using utils::Logger;
 using hyped::data::BatteryData;
-using utils::io::GPIO;
 
 namespace sensors {
 


### PR DESCRIPTION
This is for the GPIO pin 70 (port 45) to shut off HP only. As Kofi and I both agree on, it is not ideal to shut off LP during an emergency state. This is most likely to be finalised at competition with electronics when they wire up the PCB