### PR TITLE
change telemetry run_length to be static constexpr

### DIFF
--- a/src/data/data.hpp
+++ b/src/data/data.hpp
@@ -134,13 +134,13 @@ struct Motors : public Module {
 // -------------------------------------------------------------------------------------------------
 
 struct Telemetry : public Module {
+  static constexpr float run_length = 1250;  // m
   bool calibrate_command;
   bool launch_command;
   bool reset_command;
   bool service_propulsion_go;
   bool emergency_stop_command;
   bool nominal_braking_command;
-  float run_length = 1250;  // m
 };
 
 // -------------------------------------------------------------------------------------------------

--- a/src/demo_telem.cpp
+++ b/src/demo_telem.cpp
@@ -48,7 +48,6 @@ void loop(Logger& logger) {
         logger.DBG2("Telemetry", "SHARED launch_command: %s", telem_data.launch_command ? "true" : "false"); // NOLINT
         logger.DBG2("Telemetry", "SHARED calibrate_command: %s", telem_data.calibrate_command ? "true" : "false"); // NOLINT
         logger.DBG2("Telemetry", "SHARED reset_command: %s", telem_data.reset_command ? "true" : "false"); // NOLINT
-        logger.DBG2("Telemetry", "SHARED run_length: %f", telem_data.run_length);
         logger.DBG2("Telemetry", "SHARED service_propulsion_go: %s", telem_data.service_propulsion_go ? "true" : "false"); // NOLINT
         logger.DBG2("Telemetry", "SHARED emergency_stop_command: %s", telem_data.emergency_stop_command ? "true" : "false"); // NOLINT
 

--- a/src/state_machine/main.cpp
+++ b/src/state_machine/main.cpp
@@ -223,7 +223,7 @@ bool Main::checkMaxDistanceReached()
 {
   if (nav_data_.distance +
       nav_data_.braking_distance +
-      20 >= telemetry_data_.run_length) {
+      20 >= data::Telemetry::run_length) {
     log_.INFO("STATE", "max distance reached");
     log_.INFO("STATE", "current distance, braking distance: %f %f"
       , nav_data_.distance
@@ -247,7 +247,7 @@ bool Main::checkOnExit()
 bool Main::checkFinish()
 {
   // Check if end of tube was reached (leniency of 20m)
-  if (nav_data_.distance + 20 >= telemetry_data_.run_length) {
+  if (nav_data_.distance + 20 >= data::Telemetry::run_length) {
         log_.INFO("STATE", "ready for collection");
         hypedMachine.handleEvent(kFinish);
         return true;

--- a/src/telemetry/message.proto
+++ b/src/telemetry/message.proto
@@ -12,14 +12,12 @@ message ServerToClient {
         CALIBRATE = 2;
         LAUNCH = 3;
         RESET = 4;
-        RUN_LENGTH = 5;
-        SERVICE_PROPULSION_GO = 6;
-        SERVICE_PROPULSION_STOP = 7;
-        NOMINAL_BRAKING = 8;
+        SERVICE_PROPULSION_GO = 5;
+        SERVICE_PROPULSION_STOP = 6;
+        NOMINAL_BRAKING = 7;
     }
 
     Command command = 1;
-    float run_length = 2;
 }
 
 message ClientToServer {

--- a/src/telemetry/recvloop.cpp
+++ b/src/telemetry/recvloop.cpp
@@ -75,10 +75,6 @@ void RecvLoop::run()
         log_.INFO("Telemetry", "FROM SERVER: RESET");
         telem_data_struct.reset_command = true;
         break;
-      case telemetry_data::ServerToClient::RUN_LENGTH:
-        log_.INFO("Telemetry", "FROM SERVER: RUN_LENGTH %f", msg.run_length());
-        telem_data_struct.run_length = msg.run_length();
-        break;
       case telemetry_data::ServerToClient::SERVICE_PROPULSION_GO:
         log_.INFO("Telemetry", "FROM SERVER: SERVICE_PROPULSION_GO");
         telem_data_struct.service_propulsion_go = true;

--- a/src/telemetry/telemetrydata/message.pb.cpp
+++ b/src/telemetry/telemetrydata/message.pb.cpp
@@ -253,7 +253,6 @@ const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUT
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::telemetry_data::ServerToClient, command_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::telemetry_data::ServerToClient, run_length_),
   ~0u,  // no _has_bits_
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::telemetry_data::ClientToServer_Navigation, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -335,15 +334,15 @@ const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUT
 };
 static const ::google::protobuf::internal::MigrationSchema schemas[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
   { 0, -1, sizeof(::telemetry_data::ServerToClient)},
-  { 7, -1, sizeof(::telemetry_data::ClientToServer_Navigation)},
-  { 16, -1, sizeof(::telemetry_data::ClientToServer_StateMachine)},
-  { 22, -1, sizeof(::telemetry_data::ClientToServer_Motors)},
-  { 34, -1, sizeof(::telemetry_data::ClientToServer_Batteries_BatteryData)},
-  { 45, -1, sizeof(::telemetry_data::ClientToServer_Batteries)},
-  { 53, -1, sizeof(::telemetry_data::ClientToServer_Sensors_ImuData)},
-  { 60, -1, sizeof(::telemetry_data::ClientToServer_Sensors)},
-  { 67, -1, sizeof(::telemetry_data::ClientToServer_EmergencyBrakes)},
-  { 74, -1, sizeof(::telemetry_data::ClientToServer)},
+  { 6, -1, sizeof(::telemetry_data::ClientToServer_Navigation)},
+  { 15, -1, sizeof(::telemetry_data::ClientToServer_StateMachine)},
+  { 21, -1, sizeof(::telemetry_data::ClientToServer_Motors)},
+  { 33, -1, sizeof(::telemetry_data::ClientToServer_Batteries_BatteryData)},
+  { 44, -1, sizeof(::telemetry_data::ClientToServer_Batteries)},
+  { 52, -1, sizeof(::telemetry_data::ClientToServer_Sensors_ImuData)},
+  { 59, -1, sizeof(::telemetry_data::ClientToServer_Sensors)},
+  { 66, -1, sizeof(::telemetry_data::ClientToServer_EmergencyBrakes)},
+  { 73, -1, sizeof(::telemetry_data::ClientToServer)},
 };
 
 static ::google::protobuf::Message const * const file_default_instances[] = {
@@ -380,61 +379,60 @@ void protobuf_RegisterTypes(const ::std::string&) {
 void AddDescriptorsImpl() {
   InitDefaults();
   static const char descriptor[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
-      "\n\rmessage.proto\022\016telemetry_data\"\377\001\n\016Serv"
+      "\n\rmessage.proto\022\016telemetry_data\"\333\001\n\016Serv"
       "erToClient\0227\n\007command\030\001 \001(\0162&.telemetry_"
-      "data.ServerToClient.Command\022\022\n\nrun_lengt"
-      "h\030\002 \001(\002\"\237\001\n\007Command\022\007\n\003ACK\020\000\022\010\n\004STOP\020\001\022\r"
-      "\n\tCALIBRATE\020\002\022\n\n\006LAUNCH\020\003\022\t\n\005RESET\020\004\022\016\n\n"
-      "RUN_LENGTH\020\005\022\031\n\025SERVICE_PROPULSION_GO\020\006\022"
-      "\033\n\027SERVICE_PROPULSION_STOP\020\007\022\023\n\017NOMINAL_"
-      "BRAKING\020\010\"\271\r\n\016ClientToServer\022=\n\nnavigati"
-      "on\030\001 \001(\0132).telemetry_data.ClientToServer"
-      ".Navigation\022B\n\rstate_machine\030\002 \001(\0132+.tel"
-      "emetry_data.ClientToServer.StateMachine\022"
-      "5\n\006motors\030\003 \001(\0132%.telemetry_data.ClientT"
-      "oServer.Motors\022;\n\tbatteries\030\004 \001(\0132(.tele"
-      "metry_data.ClientToServer.Batteries\0227\n\007s"
-      "ensors\030\005 \001(\0132&.telemetry_data.ClientToSe"
-      "rver.Sensors\022H\n\020emergency_brakes\030\006 \001(\0132."
-      ".telemetry_data.ClientToServer.Emergency"
-      "Brakes\032\212\001\n\nNavigation\022B\n\rmodule_status\030\001"
-      " \001(\0162+.telemetry_data.ClientToServer.Mod"
-      "uleStatus\022\020\n\010distance\030\002 \001(\002\022\020\n\010velocity\030"
-      "\003 \001(\002\022\024\n\014acceleration\030\004 \001(\002\032\225\002\n\014StateMac"
-      "hine\022H\n\rcurrent_state\030\002 \001(\01621.telemetry_"
-      "data.ClientToServer.StateMachine.State\"\272"
-      "\001\n\005State\022\013\n\007INVALID\020\000\022\010\n\004IDLE\020\001\022\017\n\013CALIB"
-      "RATING\020\002\022\t\n\005READY\020\003\022\020\n\014ACCELERATING\020\004\022\023\n"
-      "\017NOMINAL_BRAKING\020\005\022\025\n\021EMERGENCY_BRAKING\020"
-      "\006\022\020\n\014RUN_COMPLETE\020\007\022\023\n\017FAILURE_STOPPED\020\010"
-      "\022\013\n\007EXITING\020\t\022\014\n\010FINISHED\020\n\032\304\001\n\006Motors\022B"
-      "\n\rmodule_status\030\001 \001(\0162+.telemetry_data.C"
-      "lientToServer.ModuleStatus\022\022\n\nvelocity_1"
-      "\030\002 \001(\021\022\022\n\nvelocity_2\030\003 \001(\021\022\022\n\nvelocity_3"
-      "\030\004 \001(\021\022\022\n\nvelocity_4\030\005 \001(\021\022\022\n\nvelocity_5"
-      "\030\006 \001(\021\022\022\n\nvelocity_6\030\007 \001(\021\032\202\003\n\tBatteries"
-      "\022B\n\rmodule_status\030\001 \001(\0162+.telemetry_data"
-      ".ClientToServer.ModuleStatus\022Q\n\023low_powe"
-      "r_batteries\030\002 \003(\01324.telemetry_data.Clien"
-      "tToServer.Batteries.BatteryData\022R\n\024high_"
-      "power_batteries\030\003 \003(\01324.telemetry_data.C"
-      "lientToServer.Batteries.BatteryData\032\211\001\n\013"
-      "BatteryData\022\017\n\007voltage\030\001 \001(\r\022\017\n\007current\030"
-      "\002 \001(\021\022\016\n\006charge\030\003 \001(\r\022\023\n\013temperature\030\004 \001"
-      "(\005\022\030\n\020low_voltage_cell\030\005 \001(\r\022\031\n\021high_vol"
-      "tage_cell\030\006 \001(\r\032\267\001\n\007Sensors\022B\n\rmodule_st"
-      "atus\030\001 \001(\0162+.telemetry_data.ClientToServ"
-      "er.ModuleStatus\022;\n\003imu\030\002 \003(\0132..telemetry"
-      "_data.ClientToServer.Sensors.ImuData\032+\n\007"
-      "ImuData\022\023\n\013operational\030\001 \001(\010\022\013\n\003acc\030\002 \003("
-      "\002\032<\n\017EmergencyBrakes\022\024\n\014front_brakes\030\001 \001"
-      "(\010\022\023\n\013rear_brakes\030\002 \001(\010\"D\n\014ModuleStatus\022"
-      "\t\n\005START\020\000\022\010\n\004INIT\020\001\022\t\n\005READY\020\002\022\024\n\020CRITI"
-      "CAL_FAILURE\020\003B\036\n\rtelemetrydataB\rTelemetr"
-      "yDatab\006proto3"
+      "data.ServerToClient.Command\"\217\001\n\007Command\022"
+      "\007\n\003ACK\020\000\022\010\n\004STOP\020\001\022\r\n\tCALIBRATE\020\002\022\n\n\006LAU"
+      "NCH\020\003\022\t\n\005RESET\020\004\022\031\n\025SERVICE_PROPULSION_G"
+      "O\020\005\022\033\n\027SERVICE_PROPULSION_STOP\020\006\022\023\n\017NOMI"
+      "NAL_BRAKING\020\007\"\271\r\n\016ClientToServer\022=\n\nnavi"
+      "gation\030\001 \001(\0132).telemetry_data.ClientToSe"
+      "rver.Navigation\022B\n\rstate_machine\030\002 \001(\0132+"
+      ".telemetry_data.ClientToServer.StateMach"
+      "ine\0225\n\006motors\030\003 \001(\0132%.telemetry_data.Cli"
+      "entToServer.Motors\022;\n\tbatteries\030\004 \001(\0132(."
+      "telemetry_data.ClientToServer.Batteries\022"
+      "7\n\007sensors\030\005 \001(\0132&.telemetry_data.Client"
+      "ToServer.Sensors\022H\n\020emergency_brakes\030\006 \001"
+      "(\0132..telemetry_data.ClientToServer.Emerg"
+      "encyBrakes\032\212\001\n\nNavigation\022B\n\rmodule_stat"
+      "us\030\001 \001(\0162+.telemetry_data.ClientToServer"
+      ".ModuleStatus\022\020\n\010distance\030\002 \001(\002\022\020\n\010veloc"
+      "ity\030\003 \001(\002\022\024\n\014acceleration\030\004 \001(\002\032\225\002\n\014Stat"
+      "eMachine\022H\n\rcurrent_state\030\002 \001(\01621.teleme"
+      "try_data.ClientToServer.StateMachine.Sta"
+      "te\"\272\001\n\005State\022\013\n\007INVALID\020\000\022\010\n\004IDLE\020\001\022\017\n\013C"
+      "ALIBRATING\020\002\022\t\n\005READY\020\003\022\020\n\014ACCELERATING\020"
+      "\004\022\023\n\017NOMINAL_BRAKING\020\005\022\025\n\021EMERGENCY_BRAK"
+      "ING\020\006\022\020\n\014RUN_COMPLETE\020\007\022\023\n\017FAILURE_STOPP"
+      "ED\020\010\022\013\n\007EXITING\020\t\022\014\n\010FINISHED\020\n\032\304\001\n\006Moto"
+      "rs\022B\n\rmodule_status\030\001 \001(\0162+.telemetry_da"
+      "ta.ClientToServer.ModuleStatus\022\022\n\nveloci"
+      "ty_1\030\002 \001(\021\022\022\n\nvelocity_2\030\003 \001(\021\022\022\n\nveloci"
+      "ty_3\030\004 \001(\021\022\022\n\nvelocity_4\030\005 \001(\021\022\022\n\nveloci"
+      "ty_5\030\006 \001(\021\022\022\n\nvelocity_6\030\007 \001(\021\032\202\003\n\tBatte"
+      "ries\022B\n\rmodule_status\030\001 \001(\0162+.telemetry_"
+      "data.ClientToServer.ModuleStatus\022Q\n\023low_"
+      "power_batteries\030\002 \003(\01324.telemetry_data.C"
+      "lientToServer.Batteries.BatteryData\022R\n\024h"
+      "igh_power_batteries\030\003 \003(\01324.telemetry_da"
+      "ta.ClientToServer.Batteries.BatteryData\032"
+      "\211\001\n\013BatteryData\022\017\n\007voltage\030\001 \001(\r\022\017\n\007curr"
+      "ent\030\002 \001(\021\022\016\n\006charge\030\003 \001(\r\022\023\n\013temperature"
+      "\030\004 \001(\005\022\030\n\020low_voltage_cell\030\005 \001(\r\022\031\n\021high"
+      "_voltage_cell\030\006 \001(\r\032\267\001\n\007Sensors\022B\n\rmodul"
+      "e_status\030\001 \001(\0162+.telemetry_data.ClientTo"
+      "Server.ModuleStatus\022;\n\003imu\030\002 \003(\0132..telem"
+      "etry_data.ClientToServer.Sensors.ImuData"
+      "\032+\n\007ImuData\022\023\n\013operational\030\001 \001(\010\022\013\n\003acc\030"
+      "\002 \003(\002\032<\n\017EmergencyBrakes\022\024\n\014front_brakes"
+      "\030\001 \001(\010\022\023\n\013rear_brakes\030\002 \001(\010\"D\n\014ModuleSta"
+      "tus\022\t\n\005START\020\000\022\010\n\004INIT\020\001\022\t\n\005READY\020\002\022\024\n\020C"
+      "RITICAL_FAILURE\020\003B\036\n\rtelemetrydataB\rTele"
+      "metryDatab\006proto3"
   };
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
-      descriptor, 2053);
+      descriptor, 2017);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "message.proto", &protobuf_RegisterTypes);
 }
@@ -465,7 +463,6 @@ bool ServerToClient_Command_IsValid(int value) {
     case 5:
     case 6:
     case 7:
-    case 8:
       return true;
     default:
       return false;
@@ -478,7 +475,6 @@ const ServerToClient_Command ServerToClient::STOP;
 const ServerToClient_Command ServerToClient::CALIBRATE;
 const ServerToClient_Command ServerToClient::LAUNCH;
 const ServerToClient_Command ServerToClient::RESET;
-const ServerToClient_Command ServerToClient::RUN_LENGTH;
 const ServerToClient_Command ServerToClient::SERVICE_PROPULSION_GO;
 const ServerToClient_Command ServerToClient::SERVICE_PROPULSION_STOP;
 const ServerToClient_Command ServerToClient::NOMINAL_BRAKING;
@@ -557,7 +553,6 @@ void ServerToClient::InitAsDefaultInstance() {
 }
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
 const int ServerToClient::kCommandFieldNumber;
-const int ServerToClient::kRunLengthFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 ServerToClient::ServerToClient()
@@ -571,16 +566,12 @@ ServerToClient::ServerToClient(const ServerToClient& from)
   : ::google::protobuf::Message(),
       _internal_metadata_(NULL) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
-  ::memcpy(&command_, &from.command_,
-    static_cast<size_t>(reinterpret_cast<char*>(&run_length_) -
-    reinterpret_cast<char*>(&command_)) + sizeof(run_length_));
+  command_ = from.command_;
   // @@protoc_insertion_point(copy_constructor:telemetry_data.ServerToClient)
 }
 
 void ServerToClient::SharedCtor() {
-  ::memset(&command_, 0, static_cast<size_t>(
-      reinterpret_cast<char*>(&run_length_) -
-      reinterpret_cast<char*>(&command_)) + sizeof(run_length_));
+  command_ = 0;
 }
 
 ServerToClient::~ServerToClient() {
@@ -611,9 +602,7 @@ void ServerToClient::Clear() {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
-  ::memset(&command_, 0, static_cast<size_t>(
-      reinterpret_cast<char*>(&run_length_) -
-      reinterpret_cast<char*>(&command_)) + sizeof(run_length_));
+  command_ = 0;
   _internal_metadata_.Clear();
 }
 
@@ -636,20 +625,6 @@ bool ServerToClient::MergePartialFromCodedStream(
                    int, ::google::protobuf::internal::WireFormatLite::TYPE_ENUM>(
                  input, &value)));
           set_command(static_cast< ::telemetry_data::ServerToClient_Command >(value));
-        } else {
-          goto handle_unusual;
-        }
-        break;
-      }
-
-      // float run_length = 2;
-      case 2: {
-        if (static_cast< ::google::protobuf::uint8>(tag) ==
-            static_cast< ::google::protobuf::uint8>(21u /* 21 & 0xFF */)) {
-
-          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
-                   float, ::google::protobuf::internal::WireFormatLite::TYPE_FLOAT>(
-                 input, &run_length_)));
         } else {
           goto handle_unusual;
         }
@@ -688,11 +663,6 @@ void ServerToClient::SerializeWithCachedSizes(
       1, this->command(), output);
   }
 
-  // float run_length = 2;
-  if (this->run_length() != 0) {
-    ::google::protobuf::internal::WireFormatLite::WriteFloat(2, this->run_length(), output);
-  }
-
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
@@ -711,11 +681,6 @@ void ServerToClient::SerializeWithCachedSizes(
   if (this->command() != 0) {
     target = ::google::protobuf::internal::WireFormatLite::WriteEnumToArray(
       1, this->command(), target);
-  }
-
-  // float run_length = 2;
-  if (this->run_length() != 0) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteFloatToArray(2, this->run_length(), target);
   }
 
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
@@ -739,11 +704,6 @@ size_t ServerToClient::ByteSizeLong() const {
   if (this->command() != 0) {
     total_size += 1 +
       ::google::protobuf::internal::WireFormatLite::EnumSize(this->command());
-  }
-
-  // float run_length = 2;
-  if (this->run_length() != 0) {
-    total_size += 1 + 4;
   }
 
   int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
@@ -776,9 +736,6 @@ void ServerToClient::MergeFrom(const ServerToClient& from) {
   if (from.command() != 0) {
     set_command(from.command());
   }
-  if (from.run_length() != 0) {
-    set_run_length(from.run_length());
-  }
 }
 
 void ServerToClient::CopyFrom(const ::google::protobuf::Message& from) {
@@ -806,7 +763,6 @@ void ServerToClient::Swap(ServerToClient* other) {
 void ServerToClient::InternalSwap(ServerToClient* other) {
   using std::swap;
   swap(command_, other->command_);
-  swap(run_length_, other->run_length_);
   _internal_metadata_.Swap(&other->_internal_metadata_);
 }
 

--- a/src/telemetry/telemetrydata/message.pb.h
+++ b/src/telemetry/telemetrydata/message.pb.h
@@ -100,10 +100,9 @@ enum ServerToClient_Command {
   ServerToClient_Command_CALIBRATE = 2,
   ServerToClient_Command_LAUNCH = 3,
   ServerToClient_Command_RESET = 4,
-  ServerToClient_Command_RUN_LENGTH = 5,
-  ServerToClient_Command_SERVICE_PROPULSION_GO = 6,
-  ServerToClient_Command_SERVICE_PROPULSION_STOP = 7,
-  ServerToClient_Command_NOMINAL_BRAKING = 8,
+  ServerToClient_Command_SERVICE_PROPULSION_GO = 5,
+  ServerToClient_Command_SERVICE_PROPULSION_STOP = 6,
+  ServerToClient_Command_NOMINAL_BRAKING = 7,
   ServerToClient_Command_ServerToClient_Command_INT_MIN_SENTINEL_DO_NOT_USE_ = ::google::protobuf::kint32min,
   ServerToClient_Command_ServerToClient_Command_INT_MAX_SENTINEL_DO_NOT_USE_ = ::google::protobuf::kint32max
 };
@@ -273,8 +272,6 @@ class ServerToClient : public ::google::protobuf::Message /* @@protoc_insertion_
     ServerToClient_Command_LAUNCH;
   static const Command RESET =
     ServerToClient_Command_RESET;
-  static const Command RUN_LENGTH =
-    ServerToClient_Command_RUN_LENGTH;
   static const Command SERVICE_PROPULSION_GO =
     ServerToClient_Command_SERVICE_PROPULSION_GO;
   static const Command SERVICE_PROPULSION_STOP =
@@ -310,18 +307,11 @@ class ServerToClient : public ::google::protobuf::Message /* @@protoc_insertion_
   ::telemetry_data::ServerToClient_Command command() const;
   void set_command(::telemetry_data::ServerToClient_Command value);
 
-  // float run_length = 2;
-  void clear_run_length();
-  static const int kRunLengthFieldNumber = 2;
-  float run_length() const;
-  void set_run_length(float value);
-
   // @@protoc_insertion_point(class_scope:telemetry_data.ServerToClient)
  private:
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   int command_;
-  float run_length_;
   mutable ::google::protobuf::internal::CachedSize _cached_size_;
   friend struct ::protobuf_message_2eproto::TableStruct;
 };
@@ -1589,20 +1579,6 @@ inline void ServerToClient::set_command(::telemetry_data::ServerToClient_Command
   
   command_ = value;
   // @@protoc_insertion_point(field_set:telemetry_data.ServerToClient.command)
-}
-
-// float run_length = 2;
-inline void ServerToClient::clear_run_length() {
-  run_length_ = 0;
-}
-inline float ServerToClient::run_length() const {
-  // @@protoc_insertion_point(field_get:telemetry_data.ServerToClient.run_length)
-  return run_length_;
-}
-inline void ServerToClient::set_run_length(float value) {
-  
-  run_length_ = value;
-  // @@protoc_insertion_point(field_set:telemetry_data.ServerToClient.run_length)
 }
 
 // -------------------------------------------------------------------


### PR DESCRIPTION
Since `run_length` is hardcoded this year decided to change it to a constexpr