### PR TITLE
Added flag --outside_run for SpaceX tests. Disables keyence usage in …

### DIFF
--- a/src/navigation/kalman_filter.cpp
+++ b/src/navigation/kalman_filter.cpp
@@ -44,7 +44,7 @@ void KalmanFilter::setup()
   // check system navigation run for R setup
   System &sys = System::getSystem();
   MatrixXf R = MatrixXf::Zero(m_, m_);;
-  if (sys.tube_run) R = createTubeMeasurementCovarianceMatrix();
+  if (sys.tube_run || sys.outside_run) R = createTubeMeasurementCovarianceMatrix();
   else if (sys.elevator_run) R = createElevatorMeasurementCovarianceMatrix();
   else if (sys.stationary_run) R = createStationaryMeasurementCovarianceMatrix();
 

--- a/src/utils/system.cpp
+++ b/src/utils/system.cpp
@@ -70,7 +70,7 @@ void printUsage()
     "    To set which IMU axis to be navigated after.\n"
     "    --axis\n"
     "    To set run kind for navigation tests.\n"
-    "    --tube_run, --elevator_run, --stationary_run\n"
+    "    --tube_run, --elevator_run, --stationary_run, --outside_run\n"
     "");
 }
 }   // namespace hyped::utils::System
@@ -109,6 +109,7 @@ System::System(int argc, char* argv[])
       tube_run(true),
       elevator_run(false),
       stationary_run(false),
+      outside_run(false),
       running_(true),
       config(0)
 {
@@ -150,6 +151,7 @@ System::System(int argc, char* argv[])
       {"tube_run", no_argument, 0, 'r'},
       {"elevator_run", no_argument, 0, 's'},
       {"stationary_run", no_argument, 0, 't'},
+      {"outside_run", no_argument, 0, 'w'},
       {0, 0, 0, 0}
     };    // options for long in long_options array, can support optional argument
     // returns option character from argv array following '-' or '--' from command line
@@ -295,6 +297,15 @@ System::System(int argc, char* argv[])
           tube_run = 0;
         } else {
           stationary_run = 1;
+          tube_run = 0;
+        }
+        break;
+      case 'w':   // outside_run
+        if (optarg) {
+          outside_run = atoi(optarg);
+          tube_run = 0;
+        } else {
+          outside_run = 1;
           tube_run = 0;
         }
         break;

--- a/src/utils/system.hpp
+++ b/src/utils/system.hpp
@@ -87,6 +87,7 @@ class System {
   bool tube_run;
   bool elevator_run;
   bool stationary_run;
+  bool outside_run;
 
   // barriers
   /**


### PR DESCRIPTION
…navigation, otherwise identical to tube_run.